### PR TITLE
CPack is case-sensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,4 @@ install(TARGETS SFML-DOOM  DESTINATION .)
 install(FILES doom1.wad DESTINATION .)
 install(DIRECTORY eawpats DESTINATION .)
 
-include(cpack)
+include(CPack)


### PR DESCRIPTION
This fixes Travis CI build errors (Linux and macOS)

cmake on Linux is case sensitive. cpack - not found, but CPack - found and works.

Everything else on Linux builds correctly and works.